### PR TITLE
changed to use import syntax

### DIFF
--- a/monitor.js
+++ b/monitor.js
@@ -1,4 +1,4 @@
-const got = require('got');
+import got from 'got';
 
 const url = "https://www.thebriarfellowship.com/product-page/pre-order-raven-claw-orb-tamper-in-two-finishes";
 
@@ -6,6 +6,6 @@ const monitor = async () => {
     
     const response = await got(url);
     console.log(response.statusCode);
-}
+};
 
 monitor();

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "This application will monitor a site for changes.",
   "main": "monitor.js",
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
The previous code used with a require statement for importing got was no longer valid and was producing an error when run.  An entry was added to the object with the `package.json` file to make this an ESM only module.  The syntax within `monitor.js` was then changed to use an import statement instead of require.